### PR TITLE
Add notice crawler based on generic scraper

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Termproject_{3}/
 │   ├── crawlers/                        # 항목별 크롤러 5종
 │   │   ├── __init__.py          # --- 패키지 초기화
 │   │   ├── academic_calendar.py # --- plus.cnu.ac.kr 학사일정 HTML/PDF 파싱
-│   │   ├── notices.py           # --- 학과·대학 공지사항 크롤링 + diff 감지
+│   │   ├── notices.py           # --- 학과·대학 공지사항 links.txt 기반 크롤링
 │   │   ├── shuttle_bus.py       # --- 셔틀버스 시간표·변경 공지 수집
 │   │   ├── graduation_req.py    # --- 졸업요건 페이지/문서 스크래핑
 │   │   └── meals.py             # --- 학식·교직원 식단표 크롤링
@@ -98,7 +98,7 @@ Termproject_{3}/
 | 파일 | 주요 클래스/함수 | 설명 |
 |------|-----------------|------|
 | `academic_calendar.py` | `AcademicCalendarCrawler(BaseCrawler)` | - 학사일정 **HTML 표 + PDF** 다운로드<br>- 월/일/이벤트 파싱 → `data/raw/…/academic.json` |
-| `notices.py` | `NoticeCrawler(BaseCrawler)`<br>`diff_notice(prev, curr)` | - 단과대·학과 **공지 게시판** 순회<br>- Body HTML → Markdown 정규화<br>- `diff_notice()`로 내용 변경 감지 & `notice_changes` 레코드 생성 |
+| `notices.py` | `NoticeCrawler(BaseCrawler)` | - `TODO_dir/cnu_crawler/data/links.txt`에 정의된 학과·대학 **공지 게시판**을 순회<br>- Generic 스크레이퍼로 제목·URL·게시일만 추출해 `data/raw/notices/…/*.csv` 저장 |
 | `shuttle_bus.py` | `ShuttleBusCrawler(BaseCrawler)` | - 셔틀 운행표∙변경 공지 크롤링<br>- 시간표 CSV·이미지 OCR 지원 |
 | `graduation_req.py` | `GraduationRequirementCrawler(BaseCrawler)` | - 졸업요건 PDF/웹 테이블 스크랩<br>- `compare_versions()`로 연도별 차이 추적 |
 | `meals.py` | `MealsCrawler(BaseCrawler)` | - 학식·교직원식단 **주간 표** 파싱<br>- 식당·식사타입별 칼로리/알러지 정보 정규화 |

--- a/run_crawlers.sh
+++ b/run_crawlers.sh
@@ -5,3 +5,4 @@ python -m src.crawlers.academic_calendar
 python -m src.crawlers.shuttle_bus
 python -m src.crawlers.graduation_req
 python -m src.crawlers.meals
+python -m src.crawlers.notices

--- a/src/crawlers/notices.py
+++ b/src/crawlers/notices.py
@@ -1,13 +1,177 @@
+"""Department notice board crawler using generic scraping."""
+
+from __future__ import annotations
+
+import csv
+import re
+import time
+from datetime import datetime
 from pathlib import Path
+from typing import Iterable, List, Tuple
+from urllib.parse import urljoin
+
+import requests
+from bs4 import BeautifulSoup, Tag
+
 from .base import BaseCrawler
 
+
+# ---------------------------------------------------------------------------
+# Utility helpers (adapted from TODO_dir/cnu_crawler project)
+
+ENCODING_FALLBACKS = ["utf-8", "euc-kr", "cp949"]
+DEFAULT_HEADERS = {
+    "User-Agent": "Mozilla/5.0 (compatible; CNUNoticeBot/1.0)"
+}
+
+
+def resilient_get(url: str, timeout: int = 10) -> requests.Response:
+    """HTTP GET with naive encoding fallback."""
+    resp = requests.get(url, headers=DEFAULT_HEADERS, timeout=timeout)
+    if resp.encoding is None or "charset" not in resp.headers.get("content-type", ""):
+        for enc in ENCODING_FALLBACKS:
+            try:
+                resp.encoding = enc
+                resp.text  # trigger decode
+                break
+            except UnicodeDecodeError:
+                continue
+    resp.raise_for_status()
+    return resp
+
+
+def normalize_whitespace(text: str) -> str:
+    return re.sub(r"\s+", " ", text).strip()
+
+
+def load_links(path: Path) -> List[Tuple[str, str, str]]:
+    """Load (college, dept, url) tuples from links.txt."""
+    rows: List[Tuple[str, str, str]] = []
+    with path.open(encoding="utf-8") as f:
+        reader = csv.reader(f)
+        for college, dept, url in reader:
+            college = college.strip()
+            dept = dept.strip()
+            if college == "-":
+                college = dept
+            if dept == "-":
+                dept = college
+            rows.append((college, dept, url.strip()))
+    return rows
+
+
+# ---------------------------------------------------------------------------
+# Generic scraper
+
+CANDIDATE_ROWS = [
+    ("table tbody tr", "td a"),
+    ("div.board_list tbody tr", "td a"),
+    ("ul li", "a"),
+    ("div.list li", "a"),
+    ("div.card", "a"),
+]
+
+_DATE_RE = re.compile(r"(20\d{2}[./-]\d{1,2}[./-]\d{1,2})|(\d{4}\.\d{2}\.\d{2})|(\d{4}-\d{2}-\d{2})")
+
+
+def _extract_date(node: Tag) -> str:
+    text = normalize_whitespace(node.get_text(" "))
+    m = _DATE_RE.search(text)
+    return m.group(0) if m else ""
+
+
+def _make_id(url: str) -> str:
+    return re.sub(r"\W+", "_", url) + "_" + str(int(time.time()))
+
+
+def scrape_generic(college: str, dept: str, url: str) -> List[dict]:
+    """Scrape a single notice list page."""
+    try:
+        resp = resilient_get(url, timeout=10)
+    except requests.HTTPError as e:
+        if e.response.status_code == 404 and "mode=list" not in url:
+            fallback = url + ("?mode=list" if "?" not in url else "&mode=list")
+            resp = resilient_get(fallback, timeout=10)
+        else:
+            raise
+
+    base = resp.url
+    soup = BeautifulSoup(resp.text, "html.parser")
+
+    rows: List[dict] = []
+    for row_sel, a_sel in CANDIDATE_ROWS:
+        parsed: List[dict] = []
+        for row in soup.select(row_sel):
+            a_tag = row.select_one(a_sel) if a_sel else row
+            if not a_tag or not a_tag.get("href"):
+                continue
+            title = normalize_whitespace(a_tag.get_text())
+            if not title:
+                continue
+            href = urljoin(base, a_tag["href"].strip())
+            parsed.append(
+                {
+                    "id": _make_id(href),
+                    "title": title,
+                    "url": href,
+                    "posted_at": _extract_date(row),
+                    "college": college,
+                    "dept": dept,
+                    "crawled_at": int(time.time()),
+                }
+            )
+        if parsed:
+            rows = parsed
+            break
+
+    if not rows:
+        raise RuntimeError(f"No rows parsed for {url}")
+
+    return rows
+
+
+# ---------------------------------------------------------------------------
+# Crawler implementation
+
+
 class NoticeCrawler(BaseCrawler):
-    def fetch(self):
-        return ''
+    """Crawl department notice boards listed in links.txt."""
 
-    def parse(self, raw):
-        return []
+    LINKS_FILE = Path("TODO_dir/cnu_crawler/data/links.txt")
 
-if __name__ == '__main__':
-    crawler = NoticeCrawler(Path('data/raw/notices'))
+    def fetch(self) -> List[Tuple[str, str, str]]:
+        return load_links(self.LINKS_FILE)
+
+    def parse(self, links: Iterable[Tuple[str, str, str]]) -> List[dict]:
+        results: List[dict] = []
+        for college, dept, url in links:
+            try:
+                rows = scrape_generic(college, dept, url)
+                results.extend(rows)
+            except Exception:
+                # Skip failures silently
+                continue
+        return results
+
+    def save(self, items: Iterable[dict]) -> None:  # type: ignore[override]
+        groups: dict[Tuple[str, str], List[dict]] = {}
+        for row in items:
+            key = (row["college"], row["dept"])
+            groups.setdefault(key, []).append(row)
+
+        for (college, dept), rows in groups.items():
+            if not rows:
+                continue
+            safe = lambda s: re.sub(r"[^\w가-힣]", "_", s)
+            fname = f"{safe(college)}_{safe(dept)}_{datetime.now().strftime('%Y%m%d')}.csv"
+            path = self.out_dir / fname
+            fieldnames = ["id", "title", "url", "posted_at", "college", "dept", "crawled_at"]
+            with open(path, "w", newline="", encoding="utf-8-sig") as f:
+                writer = csv.DictWriter(f, fieldnames=fieldnames)
+                writer.writeheader()
+                writer.writerows(rows)
+
+
+if __name__ == "__main__":
+    crawler = NoticeCrawler(Path("data/raw/notices"))
     crawler.run()


### PR DESCRIPTION
## Summary
- implement department `NoticeCrawler`
- call notice crawler in `run_crawlers.sh`
- document notice crawler configuration and output locations

## Testing
- `pip install -r requirements.txt`
- `bash run_crawlers.sh` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_6842a6990d0c832eae01b8d1366bf5b4