### PR TITLE
Fix encoding for crawlers

### DIFF
--- a/run_crawlers.sh
+++ b/run_crawlers.sh
@@ -1,8 +1,30 @@
 #!/bin/bash
 set -e
 
-python -m src.crawlers.academic_calendar
-python -m src.crawlers.shuttle_bus
-python -m src.crawlers.graduation_req
-python -m src.crawlers.meals
-python -m src.crawlers.notices
+run_and_sample() {
+  local module="$1"
+  local path="$2"
+
+  echo "Running $module..."
+  python -m "$module"
+
+  echo "Sample from $path"
+  local file
+  if [[ -f $path ]]; then
+    file="$path"
+  else
+    file=$(ls $path 2>/dev/null | head -n 1)
+  fi
+  if [[ -f $file ]]; then
+    head -n 5 "$file"
+  else
+    echo "No output file found"
+  fi
+  echo "-----"
+}
+
+run_and_sample src.crawlers.academic_calendar data/raw/academic_calendar/data.json
+run_and_sample src.crawlers.shuttle_bus data/raw/shuttle_bus/data.json
+run_and_sample src.crawlers.graduation_req data/raw/graduation_req/data.json
+run_and_sample src.crawlers.meals data/raw/meals/data.json
+run_and_sample src.crawlers.notices "data/raw/notices/*.csv"

--- a/src/crawlers/academic_calendar.py
+++ b/src/crawlers/academic_calendar.py
@@ -20,6 +20,7 @@ class AcademicCalendarCrawler(BaseCrawler):
         }
         resp = requests.get(self.BASE_URL, params=params, timeout=10)
         resp.raise_for_status()
+        resp.encoding = resp.apparent_encoding or 'utf-8'
         return resp.text
 
     def parse(self, raw: str):

--- a/src/crawlers/meals.py
+++ b/src/crawlers/meals.py
@@ -23,6 +23,7 @@ class MealsCrawler(BaseCrawler):
         }
         resp = requests.get(self.BASE_URL, params=params, timeout=10)
         resp.raise_for_status()
+        resp.encoding = resp.apparent_encoding or 'utf-8'
         return resp.text
 
     def parse(self, raw: str):

--- a/src/crawlers/shuttle_bus.py
+++ b/src/crawlers/shuttle_bus.py
@@ -10,6 +10,7 @@ class ShuttleBusCrawler(BaseCrawler):
     def fetch(self) -> str:
         resp = requests.get(self.URL, timeout=10)
         resp.raise_for_status()
+        resp.encoding = resp.apparent_encoding or 'utf-8'
         return resp.text
 
     def parse(self, raw: str):


### PR DESCRIPTION
## Summary
- ensure academic calendar, shuttle bus and meals crawlers decode UTF‑8 correctly

## Testing
- `python -m src.crawlers.academic_calendar` *(failed: ReadTimeout)*
- `python -m src.crawlers.shuttle_bus`
- `python -m src.crawlers.meals`
- `head -n 5 data/raw/academic_calendar/data.json`
- `head -n 5 data/raw/shuttle_bus/data.json`
- `head -n 5 data/raw/meals/data.json`


------
https://chatgpt.com/codex/tasks/task_e_6842abbe16c8832e9df9a5bc0458002b