### PR TITLE
Update crawlers to save crawl date and handle meal weekends

### DIFF
--- a/run_crawlers.sh
+++ b/run_crawlers.sh
@@ -26,5 +26,5 @@ run_and_sample() {
 run_and_sample src.crawlers.academic_calendar data/raw/academic_calendar/data.json
 run_and_sample src.crawlers.shuttle_bus data/raw/shuttle_bus/data.json
 run_and_sample src.crawlers.graduation_req data/raw/graduation_req/data.json
-run_and_sample src.crawlers.meals data/raw/meals/data.json
+run_and_sample src.crawlers.meals "data/raw/meals/*.json"
 run_and_sample src.crawlers.notices "data/raw/notices/*.csv"

--- a/src/crawlers/base.py
+++ b/src/crawlers/base.py
@@ -18,10 +18,17 @@ class BaseCrawler(ABC):
         """Parse raw data into structured records."""
 
     def save(self, items: Iterable[dict]) -> None:
-        path = self.out_dir / 'data.json'
+        """Save items to ``data.json`` with crawl timestamp."""
+        from datetime import datetime
         import json
+
+        path = self.out_dir / 'data.json'
+        payload = {
+            'crawled_at': datetime.now().strftime('%Y-%m-%d'),
+            'items': list(items),
+        }
         with open(path, 'w', encoding='utf-8') as f:
-            json.dump(list(items), f, ensure_ascii=False, indent=2)
+            json.dump(payload, f, ensure_ascii=False, indent=2)
 
     def run(self) -> None:
         raw = self.fetch()


### PR DESCRIPTION
## Summary
- record `crawled_at` in JSON output from all crawlers
- output meal crawler results per day and treat weekends separately
- adjust run script to sample new meal JSON files

## Testing
- `pip install -q -r requirements.txt`
- `bash run_crawlers.sh` *(fails: requests blocked / keyboard interrupt)*

------
https://chatgpt.com/codex/tasks/task_e_6842b7419a50832eb7c78d0b7af38e59