### PR TITLE
Add label-based crawler answers

### DIFF
--- a/src/answers/academic_calendar_answer.py
+++ b/src/answers/academic_calendar_answer.py
@@ -1,0 +1,33 @@
+from pathlib import Path
+import json
+from datetime import datetime
+from ..crawlers.academic_calendar import AcademicCalendarCrawler
+
+OUT_DIR = Path('data/raw/academic_calendar')
+
+
+def _load_items(path: Path):
+    if not path.exists():
+        return []
+    with path.open(encoding='utf-8') as f:
+        try:
+            return json.load(f).get('items', [])
+        except json.JSONDecodeError:
+            return []
+
+
+def generate_answer(question: str) -> str:
+    prev_path = OUT_DIR / 'data.json'
+    prev_items = _load_items(prev_path)
+    crawler = AcademicCalendarCrawler(OUT_DIR)
+    crawler.run()
+    new_items = _load_items(prev_path)
+
+    prev_set = {json.dumps(it, ensure_ascii=False, sort_keys=True) for it in prev_items}
+    new_set = {json.dumps(it, ensure_ascii=False, sort_keys=True) for it in new_items}
+    diff = [json.loads(s) for s in new_set - prev_set]
+
+    if diff:
+        events = ', '.join(f"{d['month']} {d['date']} {d['event']}" for d in diff[:3])
+        return f"새로운 학사일정이 업데이트되었습니다: {events} 등"
+    return "최근 학사일정 변동 사항이 없습니다."

--- a/src/answers/graduation_req_answer.py
+++ b/src/answers/graduation_req_answer.py
@@ -1,0 +1,31 @@
+from pathlib import Path
+import json
+from ..crawlers.graduation_req import GraduationRequirementCrawler
+
+OUT_DIR = Path('data/raw/graduation_req')
+
+
+def _load_items(path: Path):
+    if not path.exists():
+        return []
+    with path.open(encoding='utf-8') as f:
+        try:
+            return json.load(f).get('items', [])
+        except json.JSONDecodeError:
+            return []
+
+
+def generate_answer(question: str) -> str:
+    prev_path = OUT_DIR / 'data.json'
+    prev_items = _load_items(prev_path)
+    crawler = GraduationRequirementCrawler(OUT_DIR)
+    crawler.run()
+    new_items = _load_items(prev_path)
+
+    prev_set = {json.dumps(it, ensure_ascii=False, sort_keys=True) for it in prev_items}
+    new_set = {json.dumps(it, ensure_ascii=False, sort_keys=True) for it in new_items}
+    diff = [json.loads(s) for s in new_set - prev_set]
+
+    if diff:
+        return f"졸업요건 정보가 {len(diff)}건 업데이트되었습니다."
+    return "새로운 졸업요건 변경 사항이 없습니다."

--- a/src/answers/meals_answer.py
+++ b/src/answers/meals_answer.py
@@ -1,0 +1,37 @@
+from pathlib import Path
+import json
+from datetime import datetime
+from ..crawlers.meals import MealsCrawler
+
+OUT_DIR = Path('data/raw/meals')
+
+
+def _load_items(path: Path):
+    if not path.exists():
+        return []
+    with path.open(encoding='utf-8') as f:
+        try:
+            return json.load(f).get('items', [])
+        except json.JSONDecodeError:
+            return []
+
+
+def generate_answer(question: str) -> str:
+    date = datetime.now().strftime('%Y%m%d')
+    path = OUT_DIR / f'{date}.json'
+    prev_items = _load_items(path)
+    crawler = MealsCrawler(OUT_DIR)
+    crawler.run()
+    new_items = _load_items(path)
+
+    prev_set = {json.dumps(it, ensure_ascii=False, sort_keys=True) for it in prev_items}
+    new_set = {json.dumps(it, ensure_ascii=False, sort_keys=True) for it in new_items}
+    diff = [json.loads(s) for s in new_set - prev_set]
+
+    if diff:
+        sample = ', '.join(d.get('menu', '') for d in diff[:3])
+        return f"오늘 식단이 업데이트되었습니다: {sample} 등"
+    if new_items:
+        sample = ', '.join(item.get('menu', '') for item in new_items[:3])
+        return f"오늘 식단은 {sample} 등입니다."
+    return "오늘은 식단 정보가 없습니다."

--- a/src/answers/notices_answer.py
+++ b/src/answers/notices_answer.py
@@ -1,0 +1,18 @@
+from pathlib import Path
+import json
+from ..crawlers.notices import NoticeCrawler
+
+OUT_DIR = Path('data/raw/notices')
+
+
+def generate_answer(question: str) -> str:
+    before_files = {p.name for p in OUT_DIR.glob('*.csv')}
+    crawler = NoticeCrawler(OUT_DIR)
+    crawler.run()
+    after_files = {p.name for p in OUT_DIR.glob('*.csv')}
+    new_files = after_files - before_files
+
+    if new_files:
+        sample = ', '.join(list(new_files)[:3])
+        return f"새로운 공지 파일이 생성되었습니다: {sample} 등"
+    return "최근 공지사항 업데이트가 없습니다."

--- a/src/answers/shuttle_bus_answer.py
+++ b/src/answers/shuttle_bus_answer.py
@@ -1,0 +1,31 @@
+from pathlib import Path
+import json
+from ..crawlers.shuttle_bus import ShuttleBusCrawler
+
+OUT_DIR = Path('data/raw/shuttle_bus')
+
+
+def _load_items(path: Path):
+    if not path.exists():
+        return []
+    with path.open(encoding='utf-8') as f:
+        try:
+            return json.load(f).get('items', [])
+        except json.JSONDecodeError:
+            return []
+
+
+def generate_answer(question: str) -> str:
+    prev_path = OUT_DIR / 'data.json'
+    prev_items = _load_items(prev_path)
+    crawler = ShuttleBusCrawler(OUT_DIR)
+    crawler.run()
+    new_items = _load_items(prev_path)
+
+    prev_set = {json.dumps(it, ensure_ascii=False, sort_keys=True) for it in prev_items}
+    new_set = {json.dumps(it, ensure_ascii=False, sort_keys=True) for it in new_items}
+    diff = [json.loads(s) for s in new_set - prev_set]
+
+    if diff:
+        return f"셔틀버스 정보가 {len(diff)}건 업데이트되었습니다."
+    return "변경된 셔틀버스 정보가 없습니다."

--- a/src/realtime_model.py
+++ b/src/realtime_model.py
@@ -3,10 +3,38 @@ from pydantic import BaseModel
 from pathlib import Path
 import json
 from .retrieval.rag_pipeline import HybridRetriever, AnswerGenerator
+from .answers import (
+    academic_calendar_answer,
+    shuttle_bus_answer,
+    graduation_req_answer,
+    meals_answer,
+    notices_answer,
+)
+
+
+class SimpleClassifier:
+    """Very naive rule based classifier returning label 0-4."""
+
+    KEYWORDS = {
+        0: ["졸업", "졸업요건", "졸업 요건"],
+        1: ["공지", "notice"],
+        2: ["학사일정", "academic", "캘린더"],
+        3: ["식단", "학식", "메뉴"],
+        4: ["셔틀", "버스", "통학"],
+    }
+
+    def predict(self, text: str) -> int:
+        text = text.lower()
+        for label, words in self.KEYWORDS.items():
+            for w in words:
+                if w.lower() in text:
+                    return label
+        return 1
 
 app = FastAPI()
 retriever = HybridRetriever()
 generator = AnswerGenerator()
+classifier = SimpleClassifier()
 
 LOG_PATH = Path("outputs/realtime_output.json")
 
@@ -21,12 +49,27 @@ class Query(BaseModel):
 
 @app.post('/predict')
 async def predict(query: Query):
-    # Placeholder for LLM classifier
-    return {'label': 0}
+    label = classifier.predict(query.question)
+    return {'label': label}
+
+def _route_answer(label: int, question: str) -> str:
+    if label == 0:
+        return graduation_req_answer.generate_answer(question)
+    if label == 1:
+        return notices_answer.generate_answer(question)
+    if label == 2:
+        return academic_calendar_answer.generate_answer(question)
+    if label == 3:
+        return meals_answer.generate_answer(question)
+    if label == 4:
+        return shuttle_bus_answer.generate_answer(question)
+    docs = retriever.retrieve(question)
+    return generator.generate(question, docs)
+
 
 @app.post('/answer')
 async def answer(query: Query):
-    docs = retriever.retrieve(query.question)
-    text = generator.generate(query.question, docs)
-    append_log({"user": query.question, "model": text})
-    return {'answer': text, 'sources': docs}
+    label = classifier.predict(query.question)
+    text = _route_answer(label, query.question)
+    append_log({"user": query.question, "model": text, "label": label})
+    return {'answer': text, 'label': label}


### PR DESCRIPTION
## Summary
- implement simple rule-based classifier and answer routing in `realtime_model.py`
- add five answer modules that call crawlers and compute diffs

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6842fa8b1c6c832ebe001471f27f7ecc