### PR TITLE
Improve graduation req crawler and answer

### DIFF
--- a/run_answers.sh
+++ b/run_answers.sh
@@ -17,3 +17,4 @@ run_sample src.answers.academic_calendar_answer "5월 3일 학사일정 알려�
 run_sample src.answers.meals_answer "5월 3일 2학생회관 중식 뭐야"
 run_sample src.answers.notices_answer "컴퓨터공학부 공지 알려줘"
 run_sample src.answers.shuttle_bus_answer "셔틀버스 노선 알려줘"
+run_sample src.answers.graduation_req_answer "컴퓨터공학부 졸업 요건 알려줘"

--- a/run_crawlers.sh
+++ b/run_crawlers.sh
@@ -25,6 +25,6 @@ run_and_sample() {
 
 run_and_sample src.crawlers.academic_calendar data/raw/academic_calendar/data.json
 run_and_sample src.crawlers.shuttle_bus data/raw/shuttle_bus/data.json
-run_and_sample src.crawlers.graduation_req data/raw/graduation_req/data.json
+run_and_sample src.crawlers.graduation_req data/raw/graduation_req/data.csv
 run_and_sample src.crawlers.meals "data/raw/meals/*.json"
 run_and_sample src.crawlers.notices "data/raw/notices/*.csv"

--- a/src/answers/graduation_req_answer.py
+++ b/src/answers/graduation_req_answer.py
@@ -1,31 +1,74 @@
 from pathlib import Path
-import json
+import pandas as pd
+import re
+from difflib import SequenceMatcher
+
 from ..crawlers.graduation_req import GraduationRequirementCrawler
 
 OUT_DIR = Path('data/raw/graduation_req')
 
 
-def _load_items(path: Path):
+def _load_df() -> pd.DataFrame:
+    path = OUT_DIR / 'data.csv'
     if not path.exists():
-        return []
-    with path.open(encoding='utf-8') as f:
-        try:
-            return json.load(f).get('items', [])
-        except json.JSONDecodeError:
-            return []
+        return pd.DataFrame()
+    try:
+        return pd.read_csv(path)
+    except Exception:
+        return pd.DataFrame()
+
+
+def _parse_dept(q: str) -> str | None:
+    m = re.search(r'([\w가-힣]+(?:학과|학부|대학원|대학))', q)
+    return m.group(1) if m else None
+
+
+def _similar(a: str, b: str) -> float:
+    return SequenceMatcher(None, a, b).ratio()
+
+
+def _has_update_request(q: str) -> bool:
+    keywords = ['변동', '업데이트', '바뀐', '변경']
+    return any(k in q for k in keywords)
 
 
 def generate_answer(question: str) -> str:
-    prev_path = OUT_DIR / 'data.json'
-    prev_items = _load_items(prev_path)
-    crawler = GraduationRequirementCrawler(OUT_DIR)
-    crawler.run()
-    new_items = _load_items(prev_path)
+    prev_df = _load_df()
+    if _has_update_request(question):
+        crawler = GraduationRequirementCrawler(OUT_DIR)
+        try:
+            crawler.run()
+        except FileNotFoundError:
+            return '졸업요건 원본 파일이 없습니다.'
+        new_df = _load_df()
+        if prev_df.empty and new_df.empty:
+            return '졸업요건 데이터를 찾지 못했습니다.'
+        if prev_df.equals(new_df):
+            return '새로운 졸업요건 변경 사항이 없습니다.'
+        diff_rows = len(new_df.drop_duplicates().merge(prev_df.drop_duplicates(), how='outer', indicator=True).query("_merge=='left_only'"))
+        if diff_rows:
+            return f'졸업요건 정보가 {diff_rows}건 업데이트되었습니다.'
+        return '새로운 졸업요건 변경 사항이 없습니다.'
 
-    prev_set = {json.dumps(it, ensure_ascii=False, sort_keys=True) for it in prev_items}
-    new_set = {json.dumps(it, ensure_ascii=False, sort_keys=True) for it in new_items}
-    diff = [json.loads(s) for s in new_set - prev_set]
-
-    if diff:
-        return f"졸업요건 정보가 {len(diff)}건 업데이트되었습니다."
-    return "새로운 졸업요건 변경 사항이 없습니다."
+    dept = _parse_dept(question)
+    df = prev_df
+    if df.empty:
+        crawler = GraduationRequirementCrawler(OUT_DIR)
+        try:
+            crawler.run()
+        except FileNotFoundError:
+            return '졸업요건 원본 파일이 없습니다.'
+        df = _load_df()
+    if dept and not df.empty:
+        best_score = 0.0
+        best_row = None
+        for _, row in df.iterrows():
+            for cell in row.astype(str):
+                score = _similar(dept, str(cell))
+                if score > best_score:
+                    best_score = score
+                    best_row = row
+        if best_row is not None and best_score >= 0.5:
+            sample = ' '.join(str(c) for c in best_row.dropna().astype(str).tolist()[:3])
+            return f'{dept} 관련 졸업요건 정보: {sample} ...'
+    return '요청하신 졸업요건 정보를 찾지 못했습니다.'

--- a/src/crawlers/graduation_req.py
+++ b/src/crawlers/graduation_req.py
@@ -1,25 +1,47 @@
 from pathlib import Path
 import io
 import pdfplumber
+import pandas as pd
 
 from .base import BaseCrawler
 
 class GraduationRequirementCrawler(BaseCrawler):
     PDF_FILE = Path('TODO_dir/graduate/pdf/2024.pdf')
 
-    def fetch(self) -> bytes:
+    def fetch(self) -> bytes | None:
+        if not self.PDF_FILE.exists():
+            return None
         with open(self.PDF_FILE, 'rb') as f:
             return f.read()
 
-    def parse(self, raw: bytes):
+    def parse(self, raw: bytes | None):
+        if raw is None:
+            return pd.DataFrame()
         rows = []
         with pdfplumber.open(io.BytesIO(raw)) as pdf:
             for page in pdf.pages:
                 table = page.extract_table()
                 if table:
-                    for row in table:
-                        rows.append({'row': row})
-        return rows
+                    rows.extend(table)
+        if not rows:
+            return pd.DataFrame()
+        df = pd.DataFrame(rows)
+        return df
+
+    def save(self, df: pd.DataFrame) -> None:  # type: ignore[override]
+        from datetime import datetime
+
+        self.out_dir.mkdir(parents=True, exist_ok=True)
+        if df.empty:
+            # create empty file to signal run but keep previous if exists
+            path = self.out_dir / 'data.csv'
+            if not path.exists():
+                df.to_csv(path, index=False, encoding='utf-8-sig')
+            return
+
+        df['crawled_at'] = datetime.now().strftime('%Y-%m-%d')
+        path = self.out_dir / 'data.csv'
+        df.to_csv(path, index=False, encoding='utf-8-sig')
 
 if __name__ == '__main__':
     crawler = GraduationRequirementCrawler(Path('data/raw/graduation_req'))


### PR DESCRIPTION
## Summary
- parse graduation requirement PDF into a DataFrame and store as CSV
- search graduation requirements by department name using text similarity
- output updated CSV in crawler runner script
- test graduation requirement answer from run_answers.sh

## Testing
- `pip install -q -r requirements.txt`
- `pip install -q pandas`
- `./run_answers.sh > /tmp/run_answers.log && tail -n 20 /tmp/run_answers.log`

------
https://chatgpt.com/codex/tasks/task_e_68430d0cc440832e940572d324111514