### PR TITLE
Improve network handling and add offline crawl

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ Termproject_{3}/
 | 파일 | 설명 |
 |------|------|
 | `chatbot.sh` | ① **모든 크롤러 실행** → ② `build_index.py` 호출 → ③ FastAPI 실행 (uvicorn) |
+| `offline_crawl.py` | 일정 범위를 크롤링하여 **오프라인 DB** 미리 구축 |
 | `requirements.txt` | Python 패키지 고정 버전 목록 (`fastapi`, `streamlit`, `qdrant-client` …) |
 | `README.md` | **프로젝트 개요 및 파일 설명(본 문서)** |
 

--- a/src/answers/academic_calendar_answer.py
+++ b/src/answers/academic_calendar_answer.py
@@ -62,7 +62,8 @@ def generate_answer(question: str) -> str:
     if _has_update_request(question):
         prev_set = {json.dumps(it, ensure_ascii=False, sort_keys=True) for it in items}
         crawler = AcademicCalendarCrawler(OUT_DIR, year)
-        crawler.run()
+        if not crawler.run():
+            return "네트워크 오류로 학사일정을 가져오지 못했습니다."
         new_items = _load_items(path)
         new_set = {json.dumps(it, ensure_ascii=False, sort_keys=True) for it in new_items}
         diff = [json.loads(s) for s in new_set - prev_set]
@@ -84,7 +85,8 @@ def generate_answer(question: str) -> str:
     matches = _filter(items)
     if not matches:
         crawler = AcademicCalendarCrawler(OUT_DIR, year)
-        crawler.run()
+        if not crawler.run():
+            return "네트워크 오류로 학사일정을 가져오지 못했습니다."
         items = _load_items(path)
         matches = _filter(items)
 

--- a/src/answers/meals_answer.py
+++ b/src/answers/meals_answer.py
@@ -75,7 +75,8 @@ def generate_answer(question: str) -> str:
     if _has_update_request(question):
         prev_set = {json.dumps(it, ensure_ascii=False, sort_keys=True) for it in items}
         crawler = MealsCrawler(OUT_DIR, date)
-        crawler.run()
+        if not crawler.run():
+            return "네트워크 오류로 식단 정보를 가져오지 못했습니다."
         new_items = _load_items(path)
         new_set = {json.dumps(it, ensure_ascii=False, sort_keys=True) for it in new_items}
         diff = [json.loads(s) for s in new_set - prev_set]
@@ -98,7 +99,8 @@ def generate_answer(question: str) -> str:
     filtered = _filter(items)
     if not filtered:
         crawler = MealsCrawler(OUT_DIR, date)
-        crawler.run()
+        if not crawler.run():
+            return "네트워크 오류로 식단 정보를 가져오지 못했습니다."
         items = _load_items(path)
         filtered = _filter(items)
 

--- a/src/answers/notices_answer.py
+++ b/src/answers/notices_answer.py
@@ -46,7 +46,8 @@ def generate_answer(question: str) -> str:
     if _has_update_request(question):
         prev_set = {json.dumps(r, ensure_ascii=False, sort_keys=True) for r in rows}
         crawler = NoticeCrawler(OUT_DIR)
-        crawler.run()
+        if not crawler.run():
+            return "네트워크 오류로 공지사항을 가져오지 못했습니다."
         new_rows = _load_rows()
         new_set = {json.dumps(r, ensure_ascii=False, sort_keys=True) for r in new_rows}
         diff = [json.loads(s) for s in new_set - prev_set]
@@ -76,7 +77,8 @@ def generate_answer(question: str) -> str:
     filtered = _filter(rows)
     if not filtered:
         crawler = NoticeCrawler(OUT_DIR)
-        crawler.run()
+        if not crawler.run():
+            return "네트워크 오류로 공지사항을 가져오지 못했습니다."
         rows = _load_rows()
         filtered = _filter(rows)
 

--- a/src/answers/shuttle_bus_answer.py
+++ b/src/answers/shuttle_bus_answer.py
@@ -42,7 +42,8 @@ def generate_answer(question: str) -> str:
     if _has_update_request(question):
         prev_set = {json.dumps(it, ensure_ascii=False, sort_keys=True) for it in items}
         crawler = ShuttleBusCrawler(OUT_DIR)
-        crawler.run()
+        if not crawler.run():
+            return "네트워크 오류로 셔틀버스 정보를 가져오지 못했습니다."
         new_items = _load_items(path)
         new_set = {json.dumps(it, ensure_ascii=False, sort_keys=True) for it in new_items}
         diff = [json.loads(s) for s in new_set - prev_set]
@@ -69,7 +70,8 @@ def generate_answer(question: str) -> str:
     filtered = _filter(items)
     if not filtered:
         crawler = ShuttleBusCrawler(OUT_DIR)
-        crawler.run()
+        if not crawler.run():
+            return "네트워크 오류로 셔틀버스 정보를 가져오지 못했습니다."
         items = _load_items(path)
         filtered = _filter(items)
     if filtered:

--- a/src/crawlers/base.py
+++ b/src/crawlers/base.py
@@ -1,6 +1,7 @@
 from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import Any, Iterable
+import requests
 
 class BaseCrawler(ABC):
     """Abstract base class for all crawlers."""
@@ -30,7 +31,14 @@ class BaseCrawler(ABC):
         with open(path, 'w', encoding='utf-8') as f:
             json.dump(payload, f, ensure_ascii=False, indent=2)
 
-    def run(self) -> None:
-        raw = self.fetch()
+    def run(self) -> bool:
+        """Fetch, parse and save records.
+
+        Returns ``True`` when network calls succeed, ``False`` otherwise."""
+        try:
+            raw = self.fetch()
+        except requests.RequestException:
+            return False
         records = self.parse(raw)
         self.save(records)
+        return True

--- a/src/offline_crawl.py
+++ b/src/offline_crawl.py
@@ -1,0 +1,27 @@
+from datetime import datetime, timedelta
+from pathlib import Path
+
+from .crawlers.academic_calendar import AcademicCalendarCrawler
+from .crawlers.meals import MealsCrawler
+from .crawlers.shuttle_bus import ShuttleBusCrawler
+from .crawlers.graduation_req import GraduationRequirementCrawler
+from .crawlers.notices import NoticeCrawler
+
+
+def build_offline_db(year_start: int, year_end: int, days: int) -> None:
+    """Crawl a range of data to populate local cache."""
+    for year in range(year_start, year_end + 1):
+        AcademicCalendarCrawler(Path("data/raw/academic_calendar"), year).run()
+        GraduationRequirementCrawler(Path("data/raw/graduation_req"), year).run()
+
+    for d in range(days):
+        date = (datetime.now() - timedelta(days=d)).strftime("%Y%m%d")
+        MealsCrawler(Path("data/raw/meals"), date).run()
+
+    NoticeCrawler(Path("data/raw/notices")).run()
+    ShuttleBusCrawler(Path("data/raw/shuttle_bus")).run()
+
+
+if __name__ == "__main__":
+    build_offline_db(datetime.now().year - 1, datetime.now().year, 7)
+


### PR DESCRIPTION
## Summary
- handle network failures in `BaseCrawler`
- surface network error messages in answer modules
- describe `offline_crawl.py` utility in docs
- add `offline_crawl.py` script for pre-building cache

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68448caef618832e9e6d6613ecbd5f65