### PR TITLE
Launch web UI from chatbot.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Termproject_{3}/
 │   ├── chat_output.json         *# --- 챗봇 데모 세션 로그
 │   └── realtime_output.json     *# --- 실시간 API 인입/응답 기록
 │
-├── chatbot.sh                   *# --- 전체 파이프라인(크롤러→인덱스→API) 구동 스크립트
+├── chatbot.sh                   *# --- 전체 파이프라인(크롤러→인덱스→API→WebUI) 구동 스크립트
 ├── requirements.txt             *# --- Python 패키지 의존성 목록
 └── README.md                    *# --- (현재 문서)
 
@@ -159,7 +159,7 @@ Termproject_{3}/
 
 | 파일 | 설명 |
 |------|------|
-| `chatbot.sh` | ① **모든 크롤러 실행** → ② `build_index.py` 호출 → ③ FastAPI 실행 (uvicorn) |
+| `chatbot.sh` | ① **모든 크롤러 실행** → ② `build_index.py` 호출 → ③ FastAPI 실행 (uvicorn) → ④ Flask Web UI 실행 |
 | `offline_crawl.py` | 일정 범위를 크롤링하여 **오프라인 DB** 미리 구축 |
 | `requirements.txt` | Python 패키지 고정 버전 목록 (`fastapi`, `streamlit`, `qdrant-client` …) |
 | `README.md` | **프로젝트 개요 및 파일 설명(본 문서)** |

--- a/chatbot.sh
+++ b/chatbot.sh
@@ -18,13 +18,18 @@ uvicorn src.realtime_model:app --reload --port 8000 &
 SERVER_PID=$!
 sleep 3
 
+# Launch web UI in background
+python webui/app.py &
+WEBUI_PID=$!
+sleep 1
+
 # Generate evaluation outputs
 python -m src.evaluation.generate_outputs || true
 
-# Keep server running if script invoked normally
+# Keep servers running if script invoked normally
 if [[ "$EVAL_ONLY" == "1" ]]; then
-  kill $SERVER_PID
-  wait $SERVER_PID 2>/dev/null || true
+  kill $SERVER_PID $WEBUI_PID
+  wait $SERVER_PID $WEBUI_PID 2>/dev/null || true
 else
-  wait $SERVER_PID
+  wait $SERVER_PID $WEBUI_PID
 fi


### PR DESCRIPTION
## Summary
- start the Flask web UI alongside the API server in `chatbot.sh`
- document updated `chatbot.sh` behavior in the README

## Testing
- `python3 -m py_compile webui/app.py`
- `find src -name '*.py' -print0 | xargs -0 python3 -m py_compile`
- `EVAL_ONLY=1 bash chatbot.sh` *(fails: pyenv missing python version)*

------
https://chatgpt.com/codex/tasks/task_e_68448e26cca8832eb32e3716a3fdeebb