### PR TITLE
Enable offline crawler fallback

### DIFF
--- a/src/answers/__init__.py
+++ b/src/answers/__init__.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+
+from ..offline_crawl import build_offline_db
+
+
+def ensure_offline_db(days: int = 7) -> None:
+    """Run offline crawler when ``data/raw`` is empty."""
+    root = Path("data/raw")
+    if not root.exists() or not any(root.iterdir()):
+        year = datetime.now().year
+        build_offline_db(year - 1, year, days)

--- a/src/answers/academic_calendar_answer.py
+++ b/src/answers/academic_calendar_answer.py
@@ -4,6 +4,7 @@ import re
 from datetime import datetime
 from ..crawlers.academic_calendar import AcademicCalendarCrawler
 from ..retrieval.rag_pipeline import HybridRetriever
+from . import ensure_offline_db
 
 OUT_DIR = Path('data/raw/academic_calendar')
 
@@ -54,6 +55,7 @@ def _search_fallback(question: str) -> str | None:
 
 
 def generate_answer(question: str) -> str:
+    ensure_offline_db()
     year, month, day = _parse_year_month_day(question)
     year = year or datetime.now().year
     path = OUT_DIR / str(year) / 'data.json'

--- a/src/answers/graduation_req_answer.py
+++ b/src/answers/graduation_req_answer.py
@@ -4,6 +4,7 @@ import pandas as pd
 import re
 
 from ..crawlers.graduation_req import GraduationRequirementCrawler
+from . import ensure_offline_db
 
 OUT_DIR = Path("data/raw/graduation_req")
 
@@ -96,6 +97,7 @@ def _has_update_request(q: str) -> bool:
 
 
 def generate_answer(question: str) -> str:
+    ensure_offline_db()
     year = _parse_year(question)
     dept_q = _parse_dept(question)
     if not dept_q:

--- a/src/answers/meals_answer.py
+++ b/src/answers/meals_answer.py
@@ -4,6 +4,7 @@ import re
 from datetime import datetime
 from ..crawlers.meals import MealsCrawler
 from ..retrieval.rag_pipeline import HybridRetriever
+from . import ensure_offline_db
 
 
 def _is_weekend(date_str: str) -> bool:
@@ -65,6 +66,7 @@ def _search_fallback(question: str) -> str | None:
 
 
 def generate_answer(question: str) -> str:
+    ensure_offline_db()
     date = _parse_date(question)
     path = OUT_DIR / f'{date}.json'
     items = _load_items(path)

--- a/src/answers/notices_answer.py
+++ b/src/answers/notices_answer.py
@@ -6,6 +6,7 @@ from difflib import SequenceMatcher
 
 from ..crawlers.notices import NoticeCrawler
 from ..retrieval.rag_pipeline import HybridRetriever
+from . import ensure_offline_db
 
 OUT_DIR = Path('data/raw/notices')
 
@@ -41,6 +42,7 @@ def _search_fallback(question: str) -> str | None:
 
 
 def generate_answer(question: str) -> str:
+    ensure_offline_db()
     rows = _load_rows()
 
     if _has_update_request(question):

--- a/src/answers/shuttle_bus_answer.py
+++ b/src/answers/shuttle_bus_answer.py
@@ -2,6 +2,7 @@ from pathlib import Path
 import json
 from ..crawlers.shuttle_bus import ShuttleBusCrawler
 from ..retrieval.rag_pipeline import HybridRetriever
+from . import ensure_offline_db
 
 OUT_DIR = Path('data/raw/shuttle_bus')
 
@@ -36,6 +37,7 @@ def _search_fallback(question: str) -> str | None:
 
 
 def generate_answer(question: str) -> str:
+    ensure_offline_db()
     path = OUT_DIR / 'data.json'
     items = _load_items(path)
 


### PR DESCRIPTION
## Summary
- ensure that if `data/raw` is empty, the offline crawler runs
- import and call this check from all answer generators

## Testing
- `python3 -m py_compile src/answers/*.py`
- `python3 - <<'PY'
import src.answers.notices_answer as na
try:
    print(na.generate_answer('공지 알려줘'))
except Exception as e:
    print('Error:', e)
PY`

------
https://chatgpt.com/codex/tasks/task_e_6844979048b4832ea6d007a3bd221818