### PR TITLE
Improve notice & meal answers

### DIFF
--- a/data/raw/meals/20240603.json
+++ b/data/raw/meals/20240603.json
@@ -1,0 +1,156 @@
+{
+  "date": "20240603",
+  "crawled_at": "2025-06-07",
+  "items": [
+    {
+      "meal": "조식",
+      "who": "직원",
+      "cafeteria": 2,
+      "menu": "메뉴운영내역"
+    },
+    {
+      "meal": "조식",
+      "who": "직원",
+      "cafeteria": 3,
+      "menu": "정식(4000)\n\n카레라이스\n맑은우동국물\n핫도그(pork included)\n배추김치"
+    },
+    {
+      "meal": "조식",
+      "who": "직원",
+      "cafeteria": 4,
+      "menu": "운영안함"
+    },
+    {
+      "meal": "조식",
+      "who": "직원",
+      "cafeteria": 5,
+      "menu": "운영안함"
+    },
+    {
+      "meal": "조식",
+      "who": "직원",
+      "cafeteria": 6,
+      "menu": "운영안함"
+    },
+    {
+      "meal": "조식",
+      "who": "학생",
+      "cafeteria": 2,
+      "menu": "정식(1000)\n\n카레라이스\n맑은우동국물\n핫도그(pork included)\n배추김치"
+    },
+    {
+      "meal": "조식",
+      "who": "학생",
+      "cafeteria": 3,
+      "menu": "운영안함"
+    },
+    {
+      "meal": "조식",
+      "who": "학생",
+      "cafeteria": 4,
+      "menu": "운영안함"
+    },
+    {
+      "meal": "조식",
+      "who": "학생",
+      "cafeteria": 5,
+      "menu": "운영안함"
+    },
+    {
+      "meal": "중식",
+      "who": "직원",
+      "cafeteria": 2,
+      "menu": "정식(6000)\n\n안동찜닭(chicken included)\n메밀전병\n숙주나물\n배추김치"
+    },
+    {
+      "meal": "중식",
+      "who": "직원",
+      "cafeteria": 3,
+      "menu": "정식(6000)\n\n병아리콩밥\n감자다시마국\n돈김치볶음(pork included)\n삼치구이\n마늘쫑건새우볶음\n두부&양념장\n열무김치"
+    },
+    {
+      "meal": "중식",
+      "who": "직원",
+      "cafeteria": 4,
+      "menu": "운영안함"
+    },
+    {
+      "meal": "중식",
+      "who": "직원",
+      "cafeteria": 5,
+      "menu": "운영안함"
+    },
+    {
+      "meal": "중식",
+      "who": "학생",
+      "cafeteria": 2,
+      "menu": "정식(4500)\n\n치즈닭갈비덮밥(chicken included)\n맑은우동국물\n허니버터감자튀김\n요쿠르트\n단무지"
+    },
+    {
+      "meal": "중식",
+      "who": "학생",
+      "cafeteria": 3,
+      "menu": "정식(4000)\n\n김치볶음밥(pork included)\n멘츠카츠(pork included)\n누드소세지(pork included)\n(11:30~ 13:00 운영)"
+    },
+    {
+      "meal": "중식",
+      "who": "학생",
+      "cafeteria": 4,
+      "menu": "정식(6000)\n\n쌀밥\n부대찌개(pork included)\n생선까스\n닭가슴살겨자채(chicken included)\n콩나물무침\n깍두기"
+    },
+    {
+      "meal": "중식",
+      "who": "학생",
+      "cafeteria": 5,
+      "menu": "정식(6000)\n\n스팸마요덮밥(pork included)\n어묵무국\n로제떡볶이(pork included)\n고구마고로케\n단무지"
+    },
+    {
+      "meal": "석식",
+      "who": "직원",
+      "cafeteria": 2,
+      "menu": "운영안함"
+    },
+    {
+      "meal": "석식",
+      "who": "직원",
+      "cafeteria": 3,
+      "menu": "정식(6000)\n\n소불고기덮밥(beef included)\n맑은장국\n핫바\n해초곤약국수\n배추김치"
+    },
+    {
+      "meal": "석식",
+      "who": "직원",
+      "cafeteria": 4,
+      "menu": "운영안함"
+    },
+    {
+      "meal": "석식",
+      "who": "직원",
+      "cafeteria": 5,
+      "menu": "운영안함"
+    },
+    {
+      "meal": "석식",
+      "who": "학생",
+      "cafeteria": 2,
+      "menu": "운영안함"
+    },
+    {
+      "meal": "석식",
+      "who": "학생",
+      "cafeteria": 3,
+      "menu": "운영안함"
+    },
+    {
+      "meal": "석식",
+      "who": "학생",
+      "cafeteria": 4,
+      "menu": "운영안함"
+    },
+    {
+      "meal": "석식",
+      "who": "학생",
+      "cafeteria": 5,
+      "menu": "운영안함"
+    }
+  ]
+}

--- a/data/raw/notices/sample.csv
+++ b/data/raw/notices/sample.csv
@@ -1,0 +1,3 @@
+id,title,url,posted_at,college,dept,crawled_at
+1,장학금 신청 안내,http://example.com/1,2024-06-01,컴퓨터융합학부,컴퓨터융합학부,1710000000
+2,AI 세미나 공지,http://example.com/2,2024-05-30,인공지능학과,인공지능학과,1710000001

--- a/src/answers/__init__.py
+++ b/src/answers/__init__.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from datetime import datetime
 from pathlib import Path
 
-from ..offline_crawl import build_offline_db
+from importlib import import_module
 
 
 def ensure_offline_db(days: int = 7) -> None:
@@ -11,4 +11,5 @@ def ensure_offline_db(days: int = 7) -> None:
     root = Path("data/raw")
     if not root.exists() or not any(root.iterdir()):
         year = datetime.now().year
+        build_offline_db = import_module("src.offline_crawl").build_offline_db
         build_offline_db(year - 1, year, days)


### PR DESCRIPTION
## Summary
- avoid heavy offline crawler imports by lazy-loading modules
- add dynamic loading helpers for meals and notices crawlers
- fallback to previous year when meal data is missing
- include sample notice/meal data

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68449d307b00832e93f652f776c2e463