### PR TITLE
Add DB initialization and update crawlers

### DIFF
--- a/src/init_db.py
+++ b/src/init_db.py
@@ -1,0 +1,12 @@
+from datetime import datetime
+from .offline_crawl import build_offline_db
+
+
+def init_db(days: int = 7) -> None:
+    """Populate local data cache by running the offline crawler."""
+    year = datetime.now().year
+    build_offline_db(year - 1, year, days)
+
+
+if __name__ == "__main__":
+    init_db()


### PR DESCRIPTION
## Summary
- implement `init_db` helper for populating the local data cache
- refresh notice and meal data on every query

## Testing
- `bash run_crawlers.sh` *(fails: pyenv 3.10.12 not installed)*
- `bash run_answers.sh` *(fails: pyenv 3.10.12 not installed)*
- `python -m py_compile $(git ls-files '*.py')` *(fails: pyenv 3.10.12 not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6844eb181828832e849b463f76726f2f